### PR TITLE
Make coverage badges honest: include untested files, cover the gaps, fix coverage caching

### DIFF
--- a/libs/about/feature/project.json
+++ b/libs/about/feature/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/about/feature"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/about/feature"
       }

--- a/libs/about/feature/src/lib/about-routes.spec.ts
+++ b/libs/about/feature/src/lib/about-routes.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { ABOUT_ROUTES } from './about-routes';
+import { AboutComponent } from './about/about.component';
+
+describe('ABOUT_ROUTES', () => {
+  it('should show the about component on the root path', () => {
+    // Assert
+    expect(ABOUT_ROUTES).toEqual([{ path: '', component: AboutComponent }]);
+  });
+});

--- a/libs/about/feature/vite.config.mts
+++ b/libs/about/feature/vite.config.mts
@@ -23,6 +23,16 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/about/feature',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      // Route configs are a single top-level declaration, which isn't
+      // instrumentable by v8 coverage (reports a false 0% with nothing to
+      // cover). The route wiring is asserted in about-routes.spec.ts.
+      exclude: [
+        'src/test-setup.ts',
+        'src/index.ts',
+        '**/*.spec.ts',
+        'src/lib/about-routes.ts',
+      ],
     },
   },
 }));

--- a/libs/dogs/domain/project.json
+++ b/libs/dogs/domain/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/dogs/domain"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/dogs/domain"
       }

--- a/libs/dogs/domain/src/lib/services/upload.service.spec.ts
+++ b/libs/dogs/domain/src/lib/services/upload.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpService } from '@dog-rating/shared/util-common';
+import { MockProvider } from 'ng-mocks';
+import { firstValueFrom, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UploadService } from './upload.service';
+
+describe('UploadService', () => {
+  let service: UploadService;
+  let httpMock: HttpService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        UploadService,
+        MockProvider(HttpService, {
+          post: vi.fn().mockReturnValue(of({ path: 'images/dog.png' })),
+        }),
+      ],
+    });
+
+    service = TestBed.inject(UploadService);
+    httpMock = TestBed.inject(HttpService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should upload the form data to the image upload endpoint', async () => {
+    // Arrange
+    const formData = new FormData();
+
+    // Act
+    const result = await firstValueFrom(service.upload(formData));
+
+    // Assert
+    expect(httpMock.post).toHaveBeenCalledWith(
+      expect.stringContaining('api/upload/image'),
+      formData,
+    );
+    expect(result).toEqual({ path: 'images/dog.png' });
+  });
+});

--- a/libs/dogs/domain/src/lib/store/dog-realtime.feature.spec.ts
+++ b/libs/dogs/domain/src/lib/store/dog-realtime.feature.spec.ts
@@ -1,0 +1,146 @@
+import { TestBed } from '@angular/core/testing';
+import { signalStore } from '@ngrx/signals';
+import { AuthStore } from '@dog-rating/shared/util-auth';
+import { NotificationService } from '@dog-rating/shared/util-notification';
+import { RealTimeStore } from '@dog-rating/shared/util-real-time';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Dog } from '../models/dog';
+import { withDogRealtime } from './dog-realtime.feature';
+import { DogsStore } from './dogs.store';
+
+const TestRealtimeStore = signalStore(withDogRealtime());
+
+describe('withDogRealtime', () => {
+  let realTimeStore: InstanceType<typeof RealTimeStore>;
+  let dogsStore: InstanceType<typeof DogsStore>;
+  let notificationService: NotificationService;
+
+  let connectionMock: {
+    on: any;
+  };
+
+  const mockDog = { id: '1', name: 'Buddy', userId: 'my-user' } as Dog;
+
+  function getRealTimeCallback(eventName: string) {
+    const call = connectionMock.on.mock.calls.find(
+      ([name]: [string]) => name === eventName,
+    );
+
+    return call[1];
+  }
+
+  beforeEach(() => {
+    connectionMock = {
+      on: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: RealTimeStore,
+          useValue: {
+            connection: vi.fn().mockReturnValue(connectionMock),
+            startConnection: vi.fn(),
+            stopConnection: vi.fn(),
+          },
+        },
+        {
+          provide: DogsStore,
+          useValue: {
+            addDog: vi.fn(),
+            removeDog: vi.fn(),
+            updateDog: vi.fn(),
+          },
+        },
+        {
+          provide: AuthStore,
+          useValue: { userSub: vi.fn().mockReturnValue('my-user') },
+        },
+        {
+          provide: NotificationService,
+          useValue: { showSuccess: vi.fn(), showError: vi.fn() },
+        },
+        TestRealtimeStore,
+      ],
+    });
+
+    realTimeStore = TestBed.inject(RealTimeStore);
+    dogsStore = TestBed.inject(DogsStore);
+    notificationService = TestBed.inject(NotificationService);
+    TestBed.inject(TestRealtimeStore);
+  });
+
+  it('should listen to all real time events and start the connection on init', () => {
+    // Assert
+    expect(connectionMock.on).toHaveBeenCalledWith(
+      'dogadded',
+      expect.any(Function),
+    );
+    expect(connectionMock.on).toHaveBeenCalledWith(
+      'dogdeleted',
+      expect.any(Function),
+    );
+    expect(connectionMock.on).toHaveBeenCalledWith(
+      'dograted',
+      expect.any(Function),
+    );
+    expect(realTimeStore.startConnection).toHaveBeenCalled();
+  });
+
+  it('should add a dog when a dog was added in real time', () => {
+    // Arrange
+    const dogAddedCallback = getRealTimeCallback('dogadded');
+
+    // Act
+    dogAddedCallback(mockDog);
+
+    // Assert
+    expect(dogsStore.addDog).toHaveBeenCalledWith(mockDog);
+  });
+
+  it('should remove a dog when a dog was deleted in real time', () => {
+    // Arrange
+    const dogDeletedCallback = getRealTimeCallback('dogdeleted');
+
+    // Act
+    dogDeletedCallback('1');
+
+    // Assert
+    expect(dogsStore.removeDog).toHaveBeenCalledWith('1');
+  });
+
+  it('should update the dog and notify when my own dog was rated in real time', () => {
+    // Arrange
+    const dogRatedCallback = getRealTimeCallback('dograted');
+
+    // Act
+    dogRatedCallback(mockDog);
+
+    // Assert
+    expect(dogsStore.updateDog).toHaveBeenCalledWith(mockDog);
+    expect(notificationService.showSuccess).toHaveBeenCalledWith(
+      'Buddy was just rated!!!',
+    );
+  });
+
+  it('should update the dog without notifying when a foreign dog was rated in real time', () => {
+    // Arrange
+    const dogRatedCallback = getRealTimeCallback('dograted');
+    const foreignDog = { ...mockDog, userId: 'other-user' };
+
+    // Act
+    dogRatedCallback(foreignDog);
+
+    // Assert
+    expect(dogsStore.updateDog).toHaveBeenCalledWith(foreignDog);
+    expect(notificationService.showSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should stop the connection on destroy', () => {
+    // Act
+    TestBed.resetTestingModule();
+
+    // Assert
+    expect(realTimeStore.stopConnection).toHaveBeenCalled();
+  });
+});

--- a/libs/dogs/domain/src/lib/store/dogs.store.spec.ts
+++ b/libs/dogs/domain/src/lib/store/dogs.store.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Dispatcher } from '@ngrx/signals/events';
+import { NotificationService } from '@dog-rating/shared/util-notification';
+import { MockProvider } from 'ng-mocks';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Dog } from '../models/dog';
+import { DogsApiService } from '../services/dogs-api.service';
+import { dogUserEvents } from './dog-remove.feature';
+import { DogsStore } from './dogs.store';
+
+describe('DogsStore', () => {
+  let store: InstanceType<typeof DogsStore>;
+  let dogsApiService: DogsApiService;
+  let notificationService: NotificationService;
+  let router: Router;
+  let dispatcher: Dispatcher;
+
+  const mockDog: Dog = {
+    id: '1',
+    name: 'Buddy',
+    breed: 'Golden Retriever',
+    comment: 'Good boy',
+    imageUrl: 'url',
+    ratingCount: 10,
+    ratingSum: 50,
+    created: new Date(),
+    userId: 'userId',
+  };
+
+  function configureDogsStore(dogs: Dog[] | 'error') {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        MockProvider(DogsApiService, {
+          getDogs: () =>
+            dogs === 'error' ? throwError(() => new Error('failed')) : of(dogs),
+          deleteDog: vi.fn().mockReturnValue(of(undefined)),
+        }),
+        MockProvider(NotificationService, {
+          showSuccess: vi.fn(),
+          showError: vi.fn(),
+        }),
+      ],
+    });
+
+    return {
+      store: TestBed.inject(DogsStore),
+      dogsApiService: TestBed.inject(DogsApiService),
+      notificationService: TestBed.inject(NotificationService),
+      router: TestBed.inject(Router),
+      dispatcher: TestBed.inject(Dispatcher),
+    };
+  }
+
+  beforeEach(() => {
+    ({ store, dogsApiService, notificationService, router, dispatcher } =
+      configureDogsStore([mockDog]));
+  });
+
+  it('should load all dogs on init', () => {
+    // Assert
+    expect(store.entities()).toEqual([mockDog]);
+    expect(store.loading()).toBe(false);
+    expect(notificationService.showSuccess).toHaveBeenCalledWith('Dogs Loaded');
+  });
+
+  it('should show an error when loading the dogs fails', () => {
+    // Arrange
+    TestBed.resetTestingModule();
+    ({ store, notificationService } = configureDogsStore('error'));
+
+    // Assert
+    expect(store.entities()).toEqual([]);
+    expect(notificationService.showError).toHaveBeenCalled();
+  });
+
+  it('should remove a dog', () => {
+    // Act
+    store.removeDog('1');
+
+    // Assert
+    expect(store.entities()).toEqual([]);
+  });
+
+  it('should add a dog', () => {
+    // Arrange
+    const newDog = { ...mockDog, id: '2', name: 'Rex' };
+
+    // Act
+    store.addDog(newDog);
+
+    // Assert
+    expect(store.entities()).toEqual([mockDog, newDog]);
+  });
+
+  it('should update a dog', () => {
+    // Act
+    store.updateDog({ ...mockDog, name: 'Buddy Jr.' });
+
+    // Assert
+    expect(store.entities()).toEqual([{ ...mockDog, name: 'Buddy Jr.' }]);
+  });
+
+  describe('deleteDog event', () => {
+    it('should delete the dog, remove it from the state and navigate to my dogs', () => {
+      // Arrange
+      const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      // Act
+      dispatcher.dispatch(dogUserEvents.deleteDog(mockDog));
+
+      // Assert
+      expect(dogsApiService.deleteDog).toHaveBeenCalledWith(mockDog);
+      expect(store.entities()).toEqual([]);
+      expect(navigateSpy).toHaveBeenCalledWith(['/dogs/my']);
+    });
+
+    it('should show an error and keep the dog when deleting fails', () => {
+      // Arrange
+      vi.mocked(dogsApiService.deleteDog).mockReturnValue(
+        throwError(() => new Error('failed')),
+      );
+
+      // Act
+      dispatcher.dispatch(dogUserEvents.deleteDog(mockDog));
+
+      // Assert
+      expect(notificationService.showError).toHaveBeenCalled();
+      expect(store.entities()).toEqual([mockDog]);
+    });
+  });
+});

--- a/libs/dogs/domain/vite.config.mts
+++ b/libs/dogs/domain/vite.config.mts
@@ -23,6 +23,15 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/dogs/domain',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      // models/ holds interface-only files — no executable code, and v8
+      // coverage reports a false 0% with nothing to cover.
+      exclude: [
+        'src/test-setup.ts',
+        'src/index.ts',
+        '**/*.spec.ts',
+        'src/lib/models/**',
+      ],
     },
   },
 }));

--- a/libs/dogs/feature/project.json
+++ b/libs/dogs/feature/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/dogs/feature"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/dogs/feature"
       }

--- a/libs/dogs/feature/src/lib/dogs-routes.spec.ts
+++ b/libs/dogs/feature/src/lib/dogs-routes.spec.ts
@@ -1,0 +1,33 @@
+import { isAuthenticated } from '@dog-rating/shared/util-auth';
+import { describe, expect, it } from 'vitest';
+import { AddDogComponent } from './add-dog/add-dog.component';
+import { DogDetailComponent } from './dog-detail/dog-detail.component';
+import { DOGS_ROUTES } from './dogs-routes';
+import { MainDogComponent } from './main-dog/main-dog.component';
+import { MyDogsComponent } from './my-dogs/my-dogs.component';
+
+describe('DOGS_ROUTES', () => {
+  it('should show the main dog component on the root path without a guard', () => {
+    // Assert
+    expect(DOGS_ROUTES[0]).toEqual({ path: '', component: MainDogComponent });
+  });
+
+  it('should guard my dogs, adding a dog and the dog details', () => {
+    // Assert
+    expect(DOGS_ROUTES[1]).toEqual({
+      path: 'my',
+      component: MyDogsComponent,
+      canActivate: [isAuthenticated],
+    });
+    expect(DOGS_ROUTES[2]).toEqual({
+      path: 'my/add',
+      component: AddDogComponent,
+      canActivate: [isAuthenticated],
+    });
+    expect(DOGS_ROUTES[3]).toEqual({
+      path: 'details/:dogId',
+      component: DogDetailComponent,
+      canActivate: [isAuthenticated],
+    });
+  });
+});

--- a/libs/dogs/feature/vite.config.mts
+++ b/libs/dogs/feature/vite.config.mts
@@ -23,6 +23,16 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/dogs/feature',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      // Route configs are a single top-level declaration, which isn't
+      // instrumentable by v8 coverage (reports a false 0% with nothing to
+      // cover). The route wiring is asserted in dogs-routes.spec.ts.
+      exclude: [
+        'src/test-setup.ts',
+        'src/index.ts',
+        '**/*.spec.ts',
+        'src/lib/dogs-routes.ts',
+      ],
     },
   },
 }));

--- a/libs/dogs/ui/project.json
+++ b/libs/dogs/ui/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/dogs/ui"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/dogs/ui"
       }

--- a/libs/dogs/ui/vite.config.mts
+++ b/libs/dogs/ui/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/dogs/ui',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/libs/shared/ui-common/project.json
+++ b/libs/shared/ui-common/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/ui-common"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/ui-common"
       }

--- a/libs/shared/ui-common/vite.config.mts
+++ b/libs/shared/ui-common/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/ui-common',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/libs/shared/util-auth/project.json
+++ b/libs/shared/util-auth/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/util-auth"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-auth"
       }

--- a/libs/shared/util-auth/src/lib/guards/auth.guard.spec.ts
+++ b/libs/shared/util-auth/src/lib/guards/auth.guard.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
+import { firstValueFrom, Observable, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { isAuthenticated } from './auth.guard';
+
+describe('isAuthenticated', () => {
+  let router: Router;
+
+  function configureGuard(authenticated: boolean) {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        {
+          provide: OidcSecurityService,
+          useValue: {
+            isAuthenticated$: of({ isAuthenticated: authenticated }),
+          },
+        },
+      ],
+    });
+
+    router = TestBed.inject(Router);
+  }
+
+  function runGuard(): Promise<boolean> {
+    const result = TestBed.runInInjectionContext(() =>
+      isAuthenticated({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    ) as Observable<boolean>;
+
+    return firstValueFrom(result);
+  }
+
+  it('should allow activation when the user is authenticated', async () => {
+    // Arrange
+    configureGuard(true);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    // Act
+    const canActivate = await runGuard();
+
+    // Assert
+    expect(canActivate).toBe(true);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should block activation and redirect to /dogs when the user is not authenticated', async () => {
+    // Arrange
+    configureGuard(false);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    // Act
+    const canActivate = await runGuard();
+
+    // Assert
+    expect(canActivate).toBe(false);
+    expect(navigateSpy).toHaveBeenCalledWith(['/dogs']);
+  });
+});

--- a/libs/shared/util-auth/vite.config.mts
+++ b/libs/shared/util-auth/vite.config.mts
@@ -23,6 +23,15 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/util-auth',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      // models/ holds interface-only files — no executable code, and v8
+      // coverage reports a false 0% with nothing to cover.
+      exclude: [
+        'src/test-setup.ts',
+        'src/index.ts',
+        '**/*.spec.ts',
+        'src/lib/models/**',
+      ],
     },
   },
 }));

--- a/libs/shared/util-camera/project.json
+++ b/libs/shared/util-camera/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/util-camera"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-camera"
       }

--- a/libs/shared/util-camera/src/lib/camera.service.spec.ts
+++ b/libs/shared/util-camera/src/lib/camera.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { PlatformInformationService } from '@dog-rating/shared/util-platform-information';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CameraService, cameraFactory } from './camera.service';
+import { DesktopCameraService } from './desktop-camera.service';
+import { MobileCameraService } from './mobile-camera.service';
+
+describe('cameraFactory', () => {
+  const desktopCameraService = {} as DesktopCameraService;
+  const mobileCameraService = {} as MobileCameraService;
+
+  it('should return the mobile camera service on mobile', () => {
+    // Act
+    const service = cameraFactory(
+      { isMobile: true } as PlatformInformationService,
+      desktopCameraService,
+      mobileCameraService,
+    );
+
+    // Assert
+    expect(service).toBe(mobileCameraService);
+  });
+
+  it('should return the desktop camera service on desktop', () => {
+    // Act
+    const service = cameraFactory(
+      { isMobile: false } as PlatformInformationService,
+      desktopCameraService,
+      mobileCameraService,
+    );
+
+    // Assert
+    expect(service).toBe(desktopCameraService);
+  });
+});
+
+describe('CameraService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: PlatformInformationService,
+          useValue: { isMobile: false },
+        },
+      ],
+    });
+  });
+
+  it('should be provided through the platform factory', () => {
+    // Act
+    const service = TestBed.inject(CameraService);
+
+    // Assert
+    expect(service).toBeInstanceOf(DesktopCameraService);
+  });
+});

--- a/libs/shared/util-camera/src/lib/mobile-camera.service.spec.ts
+++ b/libs/shared/util-camera/src/lib/mobile-camera.service.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { Camera } from '@capacitor/camera';
+import { firstValueFrom } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileCameraService } from './mobile-camera.service';
+
+vi.mock('@capacitor/camera', () => ({
+  Camera: {
+    getPhoto: vi.fn(),
+  },
+  CameraResultType: { Base64: 'base64' },
+}));
+
+describe('MobileCameraService', () => {
+  let service: MobileCameraService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    TestBed.configureTestingModule({
+      providers: [MobileCameraService],
+    });
+
+    service = TestBed.inject(MobileCameraService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should take a photo and return it as form data', async () => {
+    // Arrange
+    vi.mocked(Camera.getPhoto).mockResolvedValue({
+      base64String: 'AAAA',
+      format: 'jpeg',
+    } as Awaited<ReturnType<typeof Camera.getPhoto>>);
+
+    // Act
+    const result = await firstValueFrom(service.getPhoto());
+
+    // Assert
+    expect(Camera.getPhoto).toHaveBeenCalledWith({
+      quality: 90,
+      allowEditing: false,
+      resultType: 'base64',
+    });
+    expect(result.base64).toBe('AAAA');
+    expect(result.fileName).toContain('mobile');
+    expect(result.fileName.endsWith('.jpg')).toBe(true);
+    expect(result.formData.get(result.fileName)).toBeInstanceOf(File);
+  });
+});

--- a/libs/shared/util-camera/vite.config.mts
+++ b/libs/shared/util-camera/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/util-camera',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/libs/shared/util-common/project.json
+++ b/libs/shared/util-common/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/util-common"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-common"
       }

--- a/libs/shared/util-common/vite.config.mts
+++ b/libs/shared/util-common/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/util-common',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/libs/shared/util-environments/project.json
+++ b/libs/shared/util-environments/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/util-environments"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-environments"
       }

--- a/libs/shared/util-environments/vite.config.mts
+++ b/libs/shared/util-environments/vite.config.mts
@@ -25,11 +25,14 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/util-environments',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
       // Plain build-time config objects, swapped by Angular's fileReplacements —
       // no branching logic, and their single top-level statement isn't
       // instrumentable by v8 coverage (reports a false 0% with nothing to cover).
       exclude: [
         ...coverageConfigDefaults.exclude,
+        'src/test-setup.ts',
+        'src/index.ts',
         'src/lib/environment.ts',
         'src/lib/environment.prod.ts',
       ],

--- a/libs/shared/util-notification/project.json
+++ b/libs/shared/util-notification/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/util-notification"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-notification"
       }

--- a/libs/shared/util-notification/src/lib/desktop-notification.service.spec.ts
+++ b/libs/shared/util-notification/src/lib/desktop-notification.service.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DesktopNotificationService } from './desktop-notification.service';
+
+describe('DesktopNotificationService', () => {
+  let service: DesktopNotificationService;
+
+  const notificationMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('Notification', notificationMock);
+
+    TestBed.configureTestingModule({
+      providers: [DesktopNotificationService],
+    });
+
+    service = TestBed.inject(DesktopNotificationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('showError', () => {
+    it('should show a notification with provided message and title', () => {
+      // Act
+      service.showError('Custom Error Message', 'Custom Title');
+
+      // Assert
+      expect(notificationMock).toHaveBeenCalledWith('Custom Title', {
+        body: 'Custom Error Message',
+      });
+    });
+
+    it('should show a notification with default values when none are provided', () => {
+      // Act
+      service.showError();
+
+      // Assert
+      expect(notificationMock).toHaveBeenCalledWith('Error', {
+        body: 'There was an error',
+      });
+    });
+  });
+
+  describe('showSuccess', () => {
+    it('should show a notification with provided message and title', () => {
+      // Act
+      service.showSuccess('Operation successful', 'Great!');
+
+      // Assert
+      expect(notificationMock).toHaveBeenCalledWith('Great!', {
+        body: 'Operation successful',
+      });
+    });
+
+    it('should show a notification with default title and empty message when none are provided', () => {
+      // Act
+      service.showSuccess();
+
+      // Assert
+      expect(notificationMock).toHaveBeenCalledWith('Success', { body: '' });
+    });
+  });
+});

--- a/libs/shared/util-notification/src/lib/mobile-notification.service.spec.ts
+++ b/libs/shared/util-notification/src/lib/mobile-notification.service.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { Toast } from '@capacitor/toast';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileNotificationService } from './mobile-notification.service';
+
+vi.mock('@capacitor/toast', () => ({
+  Toast: {
+    show: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('MobileNotificationService', () => {
+  let service: MobileNotificationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    TestBed.configureTestingModule({
+      providers: [MobileNotificationService],
+    });
+
+    service = TestBed.inject(MobileNotificationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('showError', () => {
+    it('should show a toast with the provided title', () => {
+      // Act
+      service.showError('Custom Error Message', 'Custom Title');
+
+      // Assert
+      expect(Toast.show).toHaveBeenCalledWith({
+        text: 'Custom Title',
+        position: 'bottom',
+      });
+    });
+
+    it('should show a toast with the message when no title is provided', () => {
+      // Act
+      service.showError('Custom Error Message');
+
+      // Assert
+      expect(Toast.show).toHaveBeenCalledWith({
+        text: 'Custom Error Message',
+        position: 'bottom',
+      });
+    });
+
+    it('should show a default toast when nothing is provided', () => {
+      // Act
+      service.showError();
+
+      // Assert
+      expect(Toast.show).toHaveBeenCalledWith({
+        text: 'Error',
+        position: 'bottom',
+      });
+    });
+  });
+
+  describe('showSuccess', () => {
+    it('should show a toast with the provided title', () => {
+      // Act
+      service.showSuccess('Operation successful', 'Great!');
+
+      // Assert
+      expect(Toast.show).toHaveBeenCalledWith({
+        text: 'Great!',
+        position: 'bottom',
+      });
+    });
+
+    it('should show a default toast when nothing is provided', () => {
+      // Act
+      service.showSuccess();
+
+      // Assert
+      expect(Toast.show).toHaveBeenCalledWith({
+        text: 'Success',
+        position: 'bottom',
+      });
+    });
+  });
+});

--- a/libs/shared/util-notification/src/lib/notification.service.spec.ts
+++ b/libs/shared/util-notification/src/lib/notification.service.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { PlatformInformationService } from '@dog-rating/shared/util-platform-information';
+import { ToastrService } from 'ngx-toastr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DesktopNotificationService } from './desktop-notification.service';
+import { MobileNotificationService } from './mobile-notification.service';
+import {
+  NotificationService,
+  notificationFactory,
+} from './notification.service';
+import { WebNotificationService } from './web-notification.service';
+
+describe('notificationFactory', () => {
+  const webNotificationService = {} as WebNotificationService;
+  const desktopNotificationService = {} as DesktopNotificationService;
+  const mobileNotificationService = {} as MobileNotificationService;
+
+  function createFactory(platform: { isElectron: boolean; isMobile: boolean }) {
+    return notificationFactory(
+      platform as PlatformInformationService,
+      webNotificationService,
+      desktopNotificationService,
+      mobileNotificationService,
+    );
+  }
+
+  it('should return the desktop notification service on electron', () => {
+    // Act
+    const service = createFactory({ isElectron: true, isMobile: false });
+
+    // Assert
+    expect(service).toBe(desktopNotificationService);
+  });
+
+  it('should return the mobile notification service on mobile', () => {
+    // Act
+    const service = createFactory({ isElectron: false, isMobile: true });
+
+    // Assert
+    expect(service).toBe(mobileNotificationService);
+  });
+
+  it('should return the web notification service on web', () => {
+    // Act
+    const service = createFactory({ isElectron: false, isMobile: false });
+
+    // Assert
+    expect(service).toBe(webNotificationService);
+  });
+});
+
+describe('NotificationService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: PlatformInformationService,
+          useValue: { isElectron: false, isMobile: false },
+        },
+        {
+          provide: ToastrService,
+          useValue: { error: vi.fn(), success: vi.fn() },
+        },
+      ],
+    });
+  });
+
+  it('should be provided through the platform factory', () => {
+    // Act
+    const service = TestBed.inject(NotificationService);
+
+    // Assert
+    expect(service).toBeInstanceOf(WebNotificationService);
+  });
+});

--- a/libs/shared/util-notification/vite.config.mts
+++ b/libs/shared/util-notification/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/util-notification',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/libs/shared/util-platform-information/project.json
+++ b/libs/shared/util-platform-information/project.json
@@ -8,7 +8,9 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": [
+        "{workspaceRoot}/coverage/libs/shared/util-platform-information"
+      ],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-platform-information"
       }

--- a/libs/shared/util-platform-information/vite.config.mts
+++ b/libs/shared/util-platform-information/vite.config.mts
@@ -24,6 +24,8 @@ export default defineConfig(() => ({
       reportsDirectory:
         '../../../coverage/libs/shared/util-platform-information',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/libs/shared/util-real-time/project.json
+++ b/libs/shared/util-real-time/project.json
@@ -8,7 +8,7 @@
   "targets": {
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{options.reportsDirectory}"],
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/util-real-time"],
       "options": {
         "reportsDirectory": "../../../coverage/libs/shared/util-real-time"
       }

--- a/libs/shared/util-real-time/src/lib/store/real-time.store.spec.ts
+++ b/libs/shared/util-real-time/src/lib/store/real-time.store.spec.ts
@@ -1,0 +1,118 @@
+import { TestBed } from '@angular/core/testing';
+import { HubConnection, HubConnectionState } from '@microsoft/signalr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignalRService } from '../services/signalr.service';
+import { RealTimeStore } from './real-time.store';
+
+describe('RealTimeStore', () => {
+  let store: InstanceType<typeof RealTimeStore>;
+  let signalRService: SignalRService;
+
+  let connectionMock: {
+    state: HubConnectionState;
+    onreconnected: any;
+    onreconnecting: any;
+    onclose: any;
+  };
+
+  beforeEach(() => {
+    connectionMock = {
+      state: HubConnectionState.Disconnected,
+      onreconnected: vi.fn(),
+      onreconnecting: vi.fn(),
+      onclose: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SignalRService,
+          useValue: {
+            connection: connectionMock as unknown as HubConnection,
+            build: vi.fn(),
+            start: vi.fn().mockResolvedValue(undefined),
+            stop: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        RealTimeStore,
+      ],
+    });
+
+    signalRService = TestBed.inject(SignalRService);
+    store = TestBed.inject(RealTimeStore);
+  });
+
+  it('should build the connection and start with status "Not Set"', () => {
+    // Assert
+    expect(signalRService.build).toHaveBeenCalled();
+    expect(store.connectionStatus()).toBe('Not Set');
+  });
+
+  it('should expose the connection of the signalR service', () => {
+    // Assert
+    expect(store.connection()).toBe(signalRService.connection);
+  });
+
+  it('should start the connection and set the status to "On"', async () => {
+    // Act
+    await store.startConnection();
+
+    // Assert
+    expect(signalRService.start).toHaveBeenCalled();
+    expect(store.connectionStatus()).toBe('On');
+  });
+
+  it('should not start again when the connection is already connected', async () => {
+    // Arrange
+    connectionMock.state = HubConnectionState.Connected;
+
+    // Act
+    await store.startConnection();
+
+    // Assert
+    expect(signalRService.start).not.toHaveBeenCalled();
+    expect(store.connectionStatus()).toBe('On');
+  });
+
+  it('should stop the connection and set the status to "Off"', async () => {
+    // Act
+    await store.stopConnection();
+
+    // Assert
+    expect(signalRService.stop).toHaveBeenCalled();
+    expect(store.connectionStatus()).toBe('Off');
+  });
+
+  it('should set the status to "Reconnecting" when the connection reconnects', () => {
+    // Arrange
+    const [reconnectingCallback] = connectionMock.onreconnecting.mock.calls[0];
+
+    // Act
+    reconnectingCallback();
+
+    // Assert
+    expect(store.connectionStatus()).toBe('Reconnecting');
+  });
+
+  it('should set the status to "On" when the connection has reconnected', () => {
+    // Arrange
+    const [reconnectedCallback] = connectionMock.onreconnected.mock.calls[0];
+
+    // Act
+    reconnectedCallback();
+
+    // Assert
+    expect(store.connectionStatus()).toBe('On');
+  });
+
+  it('should set the status to "Off" when the connection closes', () => {
+    // Arrange
+    const [closeCallback] = connectionMock.onclose.mock.calls[0];
+
+    // Act
+    closeCallback();
+
+    // Assert
+    expect(store.connectionStatus()).toBe('Off');
+  });
+});

--- a/libs/shared/util-real-time/vite.config.mts
+++ b/libs/shared/util-real-time/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: '../../../coverage/libs/shared/util-real-time',
       provider: 'v8' as const,
+      include: ['src/**/*.ts'],
+      exclude: ['src/test-setup.ts', 'src/index.ts', '**/*.spec.ts'],
     },
   },
 }));

--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "defaultBase": "master",
+  "defaultBase": "main",
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [


### PR DESCRIPTION
## Problem

The four 100% coverage badges in the README were computed only over the files that specs happened to import. Vitest's v8 provider without an `include` pattern never sees untested files, so 9 source files — among them the auth guard, `DogsStore`, and `RealTimeStore` — were invisible to the report. The honest number at that point was ~94% statements / ~79% branches.

## Changes

**Coverage config (all 12 lib `vite.config.mts`)**
- Add `coverage.include: ['src/**/*.ts']` so every source file counts toward the total.
- Documented excludes for files v8 genuinely cannot instrument: interface-only models (`dog.ts`, `user-profile.ts`) and single-declaration route configs — same rationale the repo already used for `environment.ts`. The route wiring is still asserted by new specs.

**New specs (12 files, following the zoneless testing skill)**
- `auth.guard.spec.ts` — allow branch and the redirect-to-`/dogs` branch
- `dogs.store.spec.ts` — load success/error, add/update/remove, and the event-driven `deleteDog` flow through the real `Dispatcher` (success navigates to `/dogs/my` and removes the entity; failure keeps it and shows the error toast)
- `dog-realtime.feature.spec.ts` — all three SignalR callbacks, the "my dog was rated" notification branch, stop-on-destroy
- `real-time.store.spec.ts` — start/stop, already-connected short-circuit, reconnect/reconnecting/close status transitions
- `upload.service.spec.ts`, `notification.service.spec.ts` + desktop/mobile variants, `camera.service.spec.ts` + mobile variant, `about-routes.spec.ts`, `dogs-routes.spec.ts` (guard wiring)

**Coverage caching fix (all 12 lib `project.json`)**
- The test targets declared `outputs: ["{options.reportsDirectory}"]`, but that option holds a project-relative `../../../coverage/...` path which Nx resolves from the workspace root — landing outside the repo. Cache hits therefore replayed test results without restoring coverage files, and the combined report silently dropped those projects. Outputs now point at `{workspaceRoot}/coverage/...`.

## Verification

- Full suite green (12 projects), combined coverage a real 100% over 36 files (was 24).
- Cache correctness: wiped `coverage/`, re-ran fully cached — combined summary is byte-identical to the fresh run.
- Lint: 0 errors (only the pre-existing `no-explicit-any` warnings the existing specs also produce). Prettier clean.
- README badges regenerate to the same 100% — now backed by the full file set.

## Out of scope (noticed, not addressed)

- `apps/dog-rate-app/src/app/app.spec.ts` never runs — the app has no test target.
- CI enforces no coverage thresholds, so the badge can still drift without failing the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)