### PR TITLE
Add honest-coverage config rules to the angular-testing skill

### DIFF
--- a/.claude/skills/angular-testing/SKILL.md
+++ b/.claude/skills/angular-testing/SKILL.md
@@ -93,6 +93,19 @@ branches, functions and lines are all 100%. Treat every gap as one of exactly tw
 missing DOM-reachable test for a real branch, or the unreachable-`computed` exception in
 `references/testing-components.md` — never leave an uncovered line unexplained.
 
+Two config rules keep that 100% honest — hold them when creating or editing a lib's test setup:
+
+- **Every lib's `vite.config.mts` sets `coverage.include: ['src/**/*.ts']`.** Without it, the
+  v8 provider only sees files the specs import, so an untested file is invisible and the number
+  lies. `exclude` is only for files with genuinely nothing to instrument (`src/test-setup.ts`,
+  the public-API `src/index.ts`, `**/*.spec.ts`, and documented cases like interface-only
+  models) — never exclude a file just because covering it is inconvenient.
+- **The `test` target's `outputs` in `project.json` uses the `{workspaceRoot}` prefix**
+  (`{workspaceRoot}/coverage/libs/<path>`), not `{options.reportsDirectory}` — that option holds
+  a project-relative `../../../` path Nx resolves from the workspace root, landing outside the
+  repo. With the wrong output, cache hits replay green tests but silently drop the lib from the
+  combined coverage report.
+
 ## Where to put the logic you're testing (so it's testable)
 
 Testing pain is usually a design smell. Before writing an elaborate DOM/async test, check the

--- a/README.md
+++ b/README.md
@@ -23,10 +23,61 @@ A demo application for uploading pictures of your dog and rate the Bois from zer
 - ✅ Cross Platform with Capacitor
 - ✅ Zoneless
 
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 20+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) — only needed if you want to run the backend locally
+
+### Run the app
+
+```sh
+npm install
+npm start
+```
+
+The Angular app is served at `http://localhost:4200`. Out of the box it talks to the hosted backend on Azure, so you don't need to run anything else to click around.
+
+### Run the backend locally (optional)
+
+```sh
+npm run run:be        # http launch profile
+npm run run:be:https  # https launch profile
+```
+
+To make the frontend use your local API instead of the hosted one, switch the `server` URL in [`libs/shared/util-environments/src/lib/environment.ts`](libs/shared/util-environments/src/lib/environment.ts) to the commented-out `localhost` entry.
+
+Or start frontend and backend together:
+
+```sh
+npm run start:all
+```
+
+## Testing
+
+```sh
+npm test              # all projects with coverage, merges the combined report, refreshes the badges
+npm run test:watch    # watch mode
+npm run lint          # lint all projects
+```
+
+Tests run on [Vitest](https://vitest.dev/) in a fully zoneless setup. `npm test` writes per-project coverage to `coverage/libs/**` and merges everything into `coverage/combined/index.html` — the badges above come from that combined report.
+
+## Building
+
+```sh
+npm run build          # web build (dist/)
+npm run build-desktop  # desktop app via Electron
+npm run build-mobile   # iOS/Android via Capacitor
+```
+
+## Architecture
+
+An Nx monorepo with enforced module boundaries: `apps/` contains the Angular host (`dog-rate-app`), the Playwright e2e project and the .NET API (`dotnet-dog-api`); `libs/` is sliced per scope into `feature` (routed containers), `ui` (presentational components), `domain` (stores + API services) and `util-*` (auth, camera, notifications, real-time, platform detection).
+
+![Arch Graph](.github/graph.png)
+
 ## Authors
 
 - [@FabianGosebrink](https://twitter.com/FabianGosebrink)
-
-## Screenshots
-
-![Arch Graph](.github/graph.png)


### PR DESCRIPTION
## What

Follow-up to #13. The specs in that PR were written following the `angular-testing` skill, but the skill itself did not yet know the two config rules that keep the 100% badge honest. This adds them to the skill's coverage section:

- **`coverage.include: ['src/**/*.ts']` in every lib's `vite.config.mts`** — without it, the v8 provider only sees files the specs import, so an untested file is invisible and the number lies. `exclude` stays reserved for files with genuinely nothing to instrument (test setup, public-API `index.ts`, spec files, documented cases like interface-only models) — never for files that are merely inconvenient to cover.
- **`outputs: ["{workspaceRoot}/coverage/..."]` on the `test` target in `project.json`** — not `{options.reportsDirectory}`, whose project-relative path Nx resolves from the workspace root, landing outside the repo. With the wrong output, cache hits replay green tests but silently drop the lib from the combined coverage report.

## Why

An agent creating a new lib in this workspace should set up honest coverage from the start instead of reintroducing the exact bug #13 fixed. This also keeps the skill aligned with the book's testing chapter, which now documents both rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)